### PR TITLE
Update electrostaticpotential.py

### DIFF
--- a/PoltypeModules/electrostaticpotential.py
+++ b/PoltypeModules/electrostaticpotential.py
@@ -69,7 +69,7 @@ def gen_esp_grid(poltype,mol,gridnamelist,espnamelist,fchknamelist,cubenamelist)
 
     for i in range(len(gridnamelist)):
         gridname=gridnamelist[i]
-        espname=espnamelist[i]
+        espname=espnamelist[i]c
         fchkname=fchknamelist[i]
         cubename=cubenamelist[i]
         potfile=cubename.replace('.cube','.pot') 
@@ -133,10 +133,11 @@ def CreatePsi4ESPInputFile(poltype,comfilecoords,comfilename,mol,maxdisk,maxmem,
     temp.write('set freeze_core True'+'\n')
     temp.write('set PROPERTIES_ORIGIN ["COM"]'+'\n')
     temp.write("set cubeprop_tasks ['esp']"+'\n')
-
+    temp.write('set basis %s '%(poltype.espbasisset)+'\n')
+    
     if poltype.allowradicals==True:
         temp.write('set reference uhf '+'\n')
-        temp.write("G, wfn = gradient('%s/%s', return_wfn=True)" % (poltype.espmethod.lower(),poltype.espbasisset)+'\n')
+        temp.write("G, wfn = gradient('%s', return_wfn=True)" % (poltype.espmethod.lower())+'\n')
     else:
         spacedformulastr=mol.GetSpacedFormula()
         if ('I ' in spacedformulastr):
@@ -147,7 +148,7 @@ def CreatePsi4ESPInputFile(poltype,comfilecoords,comfilename,mol,maxdisk,maxmem,
             temp.write("E, wfn = properties('%s',properties=['dipole'],return_wfn=True)" % (poltype.espmethod.lower())+'\n')
         else:
 
-            temp.write("E, wfn = properties('%s/%s',properties=['dipole'],return_wfn=True)" % (poltype.espmethod.lower(),poltype.espbasisset)+'\n')
+            temp.write("E, wfn = properties('%s',properties=['dipole'],return_wfn=True)" % (poltype.espmethod.lower())+'\n')
     temp.write('cubeprop(wfn)'+'\n')
     temp.write('fchk(wfn, "%s.fchk")'%(comfilename.replace('.com',''))+'\n')
 
@@ -182,10 +183,12 @@ def CreatePsi4DMAInputFile(poltype,comfilecoords,comfilename,mol):
     temp.write('set freeze_core True'+'\n')
     temp.write('set PROPERTIES_ORIGIN ["COM"]'+'\n')
     temp.write("set cubeprop_tasks ['esp']"+'\n')
+    temp.write('set basis %s '%(poltype.dmabasisset)+'\n')
+    
     if poltype.allowradicals==True:
         temp.write('set reference uhf '+'\n')
 
-        temp.write("G, wfn = gradient('%s/%s', return_wfn=True)" % (poltype.dmamethod.lower(),poltype.dmabasisset)+'\n')
+        temp.write("G, wfn = gradient('%s', return_wfn=True)" % (poltype.dmamethod.lower())+'\n')
     else:
         spacedformulastr=mol.GetSpacedFormula()
         if ('I ' in spacedformulastr):
@@ -197,7 +200,7 @@ def CreatePsi4DMAInputFile(poltype,comfilecoords,comfilename,mol):
 
         else:
 
-            temp.write("E, wfn = properties('%s/%s',properties=['dipole'],return_wfn=True)" % (poltype.dmamethod.lower(),poltype.dmabasisset)+'\n')
+            temp.write("E, wfn = properties('%s',properties=['dipole'],return_wfn=True)" % (poltype.dmamethod.lower())+'\n')
     temp.write('cubeprop(wfn)'+'\n')
     temp.write('fchk(wfn, "%s.fchk")'%(comfilename.replace('.com',''))+'\n')
     header=poltype.molstructfname.split('.')[0]

--- a/PoltypeModules/electrostaticpotential.py
+++ b/PoltypeModules/electrostaticpotential.py
@@ -69,7 +69,7 @@ def gen_esp_grid(poltype,mol,gridnamelist,espnamelist,fchknamelist,cubenamelist)
 
     for i in range(len(gridnamelist)):
         gridname=gridnamelist[i]
-        espname=espnamelist[i]c
+        espname=espnamelist[i]
         fchkname=fchknamelist[i]
         cubename=cubenamelist[i]
         potfile=cubename.replace('.cube','.pot') 


### PR DESCRIPTION
When using MP2 for dma step for some reason Psi4 runs into an error saying "Orbital basis argument must not be empty". I added an individual line for setting the basis set instead of having it beside the qm method and it actually worked. Please let me know what you think about that change. I did it for both dma and esp step.

Best,
Hesam