### PR TITLE
Update KillJob to kill leftover child processes

### DIFF
--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -2373,11 +2373,14 @@ class PolarizableTyper():
 
         def KillJob(self,job,outputlog):
             p=self.cmdtopid[job]
-            pid=p.pid
-            p.terminate()
-            p.wait()
+            try:
+                p.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                process = psutil.Process(p.pid)
+                for proc in process.children(recursive=True):
+                    proc.kill()
+                process.kill()
 
-        
         def CallJobsSeriallyLocalHost(self,fulljobtooutputlog,skiperrors,wait=False):
            thepath=os.path.join(os.getcwd(),'Fragments')
            finishedjobs=[]


### PR DESCRIPTION
I've tested it with up to ~200 molecules. It's been working fine to reap all child processes.