### PR TITLE
Change smart strings for Amide torsion match

### DIFF
--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -5,5 +5,5 @@
 [*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
 [*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
 [#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
-[#8]=[#6][#7X3;H1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X

--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -2,8 +2,8 @@
 # Torsional parameters for AMOEBA force field
 #
 # Format: SMARTS string 		  	% Four indices     % 3-fold parameters              % Comments for source of parameters
-[*;!#1][#6](=[#8])[#7X3;H0] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
 [*;!#1][#6](=[#8])[#7X3;H1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
-[#8]=[#6][#7X3;H0] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
+[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
 [#8]=[#6][#7X3;H1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X

--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -2,8 +2,8 @@
 # Torsional parameters for AMOEBA force field
 #
 # Format: SMARTS string 		  	% Four indices     % 3-fold parameters              % Comments for source of parameters
-[*;!#1][#6](=[#8])[#7][*;!#1] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
-[#8]=[#6][#7][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
-[#8]=[#6][#7][#1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3;H0] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3;H1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
+[#8]=[#6][#7X3;H0] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
+[#8]=[#6][#7X3;H1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X

--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -6,9 +6,9 @@
 #[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
 #[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
 #[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7X3][*;!#1] 	% 1,2,4,5          % -1.000,  6.500,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7X3][#1] 			% 1,2,4,5          %  0.000,  1.500,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
-[#8]=[#6][#7X3][*;!#1] 						% 1,2,3,4          %  1.000,  6.500, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
-[#8]=[#6][#7X3][#1] 							% 1,2,3,4          %  0.000, 1.500, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3][*;!#1] 	% 1,2,4,5          % -1.000,  5.425,  2.000 				% Amide X-C-N-X taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3][#1] 			% 1,2,4,5          %  0.000,  4.425,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
+[#8]=[#6][#7X3][*;!#1] 						% 1,2,3,4          %  1.000,  5.675, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
+[#8]=[#6][#7X3][#1] 							% 1,2,3,4          %  0.000, 4.425, -0.550 				% Amide O=C-N-H taken from amoeba09 Acetamide
 
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X

--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -3,7 +3,7 @@
 #
 # Format: SMARTS string 		  	% Four indices     % 3-fold parameters              % Comments for source of parameters
 [*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7X3;H1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
 [#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
 [#8]=[#6][#7X3;H1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X

--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -2,8 +2,13 @@
 # Torsional parameters for AMOEBA force field
 #
 # Format: SMARTS string 		  	% Four indices     % 3-fold parameters              % Comments for source of parameters
-[*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
-[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
-[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+#[*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  2.000,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
+#[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
+#[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
+#[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  6.500,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.500,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
+[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  6.500, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
+[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, 1.500, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X

--- a/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
+++ b/PoltypeModules/lDatabaseParser/prm/amoebaTorsion.prm
@@ -6,9 +6,9 @@
 #[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.200,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
 #[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  2.250, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
 #[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, -0.664, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7X3;H0][*;!#1] 	% 1,2,4,5          % -1.000,  6.500,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
-[*;!#1][#6](=[#8])[#7X3;H1][#1] 			% 1,2,4,5          %  0.000,  1.500,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
-[#8]=[#6][#7X3;H0][*;!#1] 						% 1,2,3,4          %  1.000,  6.500, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
-[#8]=[#6][#7X3;H1][#1] 							% 1,2,3,4          %  0.000, 1.500, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3][*;!#1] 	% 1,2,4,5          % -1.000,  6.500,  2.050 				% Amide X-C-N-X taken from amoeba09 Acetamide
+[*;!#1][#6](=[#8])[#7X3][#1] 			% 1,2,4,5          %  0.000,  1.500,  0.800 				% Amide X-C-N-H taken from amoeba09 Acetamide
+[#8]=[#6][#7X3][*;!#1] 						% 1,2,3,4          %  1.000,  6.500, -2.250 				% Amide O=C-N-X taken from amoeba09 Acetamide
+[#8]=[#6][#7X3][#1] 							% 1,2,3,4          %  0.000, 1.500, -0.357 				% Amide O=C-N-H taken from amoeba09 Acetamide
 
 [H][N][a][a] 										% 1,2,3,4          % -0.584,  5.016, -0.552  				% Aniline and Aniline-like molecule H-N-C-X


### PR DESCRIPTION
@leucinw  The goal is to change the smart pattern for amide in order to not recognize AMIDE groups that have a nitrogen with only 2 bonds (N-) 
