### PR TITLE
Add function to read sdf file in lConfomer Generator

### DIFF
--- a/PoltypeModules/lConformerGenerator.py
+++ b/PoltypeModules/lConformerGenerator.py
@@ -149,15 +149,6 @@ if __name__ == "__main__":
   # check if molecule is 2D
   if inputformat == "SDF":
     check_2D_mol(inputfile)
-    coords_z = []
-    lines = open(inputfile).readlines()
-    for line in lines:
-      ss = line.split()
-      if len(ss) == 16:
-        coords_z.append(float(ss[2]))
-    if (all(coords_z) == 0):
-      os.system(f"obabel {inputfile} -O {inputfile} --gen3d")
-      print(f" Converting {inputfile} to 3D")
 
   if inputformat == 'MOL2':
     m1 = Chem.MolFromMol2File(inputfile,removeHs=False)

--- a/PoltypeModules/lConformerGenerator.py
+++ b/PoltypeModules/lConformerGenerator.py
@@ -96,6 +96,43 @@ def no_close_contact(conf, atom_pairs, threshold=2.5):
       break
   return res
 
+
+def check_2D_mol(inputfile):
+
+  """
+  This function checks if the molecule in the initial sdf
+  is in 2D or not. 
+  If yes, then convert to 3D with openbabel
+
+  Inputs:
+     -   inputfile: name of initial sdf file
+  """
+
+  # Define number of header line in sdf file
+  header = 4
+
+  # Get total number of atoms using RDKit
+  mol = Chem.SDMolSupplier(inputfile, removeHs=False)
+  nbr_atom = mol[0].GetNumAtoms()
+  Z = []
+
+  # Read sdf file and grep only the Z coordinates
+  with open(inputfile) as f:
+    for index,lines in enumerate(f):
+      print(index,lines)
+      if index >= header and index < (header + nbr_atom):
+        Z.append(float(lines.strip('\n').split()[2]))
+
+      if 'CHG' in lines or 'END' in lines:
+        break
+
+  if (all(Z) == 0):
+    os.system(f"obabel {inputfile} -O {inputfile} --gen3d")
+    print(f" Converting {inputfile} to 3D")
+
+  return
+
+
 if __name__ == "__main__":
  
   parser = argparse.ArgumentParser()
@@ -111,6 +148,7 @@ if __name__ == "__main__":
 
   # check if molecule is 2D
   if inputformat == "SDF":
+    check_2D_mol(inputfile)
     coords_z = []
     lines = open(inputfile).readlines()
     for line in lines:


### PR DESCRIPTION
@leucinw an issue was found with the code lConformerGenerator.py

It is possible to have a line that once `split` will have a length of 16 and not be part of the geometry. For example a commented line or something. 

in that case, the lConformerGenerator will fail as it can not convert string to float. 
I propose the following changes to make sure that when checking for 2D molecule only the geometry part is read.

What do you think? 