### PR TITLE
Use PYSCF for PCM calculations

### DIFF
--- a/PoltypeModules/optimization.py
+++ b/PoltypeModules/optimization.py
@@ -719,6 +719,7 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
 
 
     print('TM in GeometryOptimization:')
+    print(logoptfname)
     if not poltype.use_gaus or not poltype.use_gausoptonly:
         if poltype.optpcm==True or (poltype.optpcm==-1 and poltype.pcm):
             Soft = 'PySCF'
@@ -809,6 +810,24 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
 
         print(Opt_prep.mol_data_init)
 
+
+        cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} > {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
+
+        cmd_to_run = {cmd: f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'}
+
+        if poltype.checkinputonly==True:
+            sys.exit()
+
+        if os.path.isfile(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'):
+            os.remove(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}')
+
+        print(cmd)
+
+        if poltype.externalapi==None:
+            print('Is Poltype not external API')
+            print(cmd)
+            finishedjobs,errorjobs=poltype.CallJobsSeriallyLocalHost(cmd_to_run,skiperrors)
+
         
         #sys.exit()
 
@@ -841,6 +860,7 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
                 os.remove(logoptfname)
             if poltype.externalapi==None:
                 print('Is Poltype not external API')
+                print(jobtooutputlog)
                 finishedjobs,errorjobs=poltype.CallJobsSeriallyLocalHost(jobtooutputlog,skiperrors)
             else:
                 print('It is poltype external API')

--- a/PoltypeModules/optimization.py
+++ b/PoltypeModules/optimization.py
@@ -23,6 +23,11 @@ def GeometryOPTWrapper(poltype,molist):
     Referenced By: 
     Description: 
     """
+    
+    ######
+    # TM: GeometryOptimization is being called here
+    #####
+
     optmolist=[]
     errorlist=[]
     torsionrestraintslist=[]
@@ -283,6 +288,10 @@ def GrabFinalXYZStructure(poltype,logname,filename,mol):
     Referenced By: 
     Description: 
     """
+    #######
+    # TM: Need to change this function to handle Psi4 or other software
+    ######
+
     checkifpsi4=CheckIfPsi4Log(poltype,logname)
     if checkifpsi4==True:
         temp=open(logname,'r')
@@ -703,6 +712,9 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
     Description: 
     """
 
+    
+
+
     NATOM_SMALL = 25
     if bondanglerestraints!=None or \
         (poltype.generateextendedconf==False and poltype.userconformation==False) or \
@@ -714,6 +726,10 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
     logoptfname=poltype.logoptfname.replace('_1','_'+suffix)
     comoptfname=poltype.comoptfname.replace('_1','_'+suffix)
     chkoptfname=poltype.chkoptfname.replace('_1','_'+suffix)
+
+    #######
+    # TM: Need to change here to deal with other type of software
+    ######
 
     if (poltype.use_gaus==True or poltype.use_gausoptonly==True): # try to use gaussian for opt
         term,error=poltype.CheckNormalTermination(logoptfname,errormessages=None,skiperrors=True)

--- a/PoltypeModules/optimization.py
+++ b/PoltypeModules/optimization.py
@@ -755,6 +755,8 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
         term,error=poltype.CheckNormalTermination(logoptfname,errormessages=None,skiperrors=True)
         modred=False
 
+        if poltype.optpcm==True or (poltype.optpcm==-1 and poltype.pcm):
+            print('###### Create_PySCF_input #######')
         inputname,outputname=CreatePsi4OPTInputFile(poltype,comoptfname,comoptfname,mol,modred,bondanglerestraints,skipscferror,charge,loose,torsionrestraints)
         if term==False or overridecheckterm==True:
             poltype.WriteToLog("QM Geometry Optimization")

--- a/PoltypeModules/optimization.py
+++ b/PoltypeModules/optimization.py
@@ -794,6 +794,7 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
         print('torsionrestraints',torsionrestraints)
         print('skiperror', skiperrors)
         from pyscf_setup import PySCF_init_setup
+        from pyscf_setup import PySCF_post_run
 
 
         Opt_prep = PySCF_init_setup(poltype,os.getcwd(),comoptfname,mol,\
@@ -843,10 +844,13 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
             print('Waiting for termination')
             finishedjobs,errorjobs=poltype.WaitForTermination(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}',False) 
 
-        #term,error=poltype.CheckNormalTermination(f'{Opt_prep.PySCF_out_file}',None,skiperrors)
-        term,error=poltype.CheckNormalTermination(f'switterion-opt_1_test_fail2.out',None,skiperrors)
+        term,error=poltype.CheckNormalTermination(f'{Opt_prep.PySCF_out_file}',None,skiperrors)
+        #term,error=poltype.CheckNormalTermination(f'switterion-opt_1_test_fail2.out',None,skiperrors)
         if error and term==False and skiperrors==False:
-            poltype.RaiseOutputFileError(f'switterion-opt_1_test_fail2.out')
+            poltype.RaiseOutputFileError(f'{Opt_prep.PySCF_out_file}')
+
+
+        Opt_post = PySCF_post_run(f'{Opt_prep.PySCF_out_file}') 
 
         sys.exit()
 

--- a/PoltypeModules/optimization.py
+++ b/PoltypeModules/optimization.py
@@ -784,8 +784,7 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
 
         # Instantiate the initial pyscf setup object
         Opt_prep = PySCF_init_setup(poltype,os.getcwd(),comoptfname,mol,\
-                               modred,bondanglerestraints,skipscferror,\
-                               charge,loose,torsionrestraints)
+                               skipscferror,charge)
     
         # Read the gaussian input coordinate
         Opt_prep.read_Gauss_inp_coord()
@@ -795,10 +794,10 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
 
         # Write the torsion constraints to be used 
         # during the QM optimization
-        Opt_prep.write_geometric_tor_const('init')
+        Opt_prep.write_geometric_tor_const('init',torsionrestraints)
 
         # Write the PySCF input file
-        Opt_prep.write_PySCF_input()
+        Opt_prep.write_PySCF_input(True,False)
 
         # Define the cmd to run PySCF
         cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} &> {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
@@ -822,6 +821,8 @@ def GeometryOptimization(poltype,mol,totcharge,suffix='1',loose=False,checkbonds
             #    pass
             #else:
             finishedjobs,errorjobs=poltype.CallJobsSeriallyLocalHost(cmd_to_run,skiperrors)
+            print('Optimization for parent ligand')
+            print(finishedjobs,errorjobs)
         else:
             print('PySCF for external API')
             jobtoinputfilepaths = {cmd: [f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file}']}
@@ -914,10 +915,6 @@ def load_structfile(poltype,structfname):
     Referenced By: run_gaussian, tor_opt_sp, compute_qm_tor_energy, compute_mm_tor_energy 
     Description: -
     """
-
-    with open(structfname, 'r') as f:
-        for lines in f:
-            print(lines)
 
     strctext = os.path.splitext(structfname)[1]
     tmpconv = openbabel.OBConversion()

--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -3409,6 +3409,10 @@ class PolarizableTyper():
             os.chdir(curdir)
             # STEP 2
             htime=min(lastupdatetofilename.keys())
+            print('')
+            print('')
+            print('########')
+            print(logfname)
             if os.path.isfile(logfname):
                 head,tail=os.path.split(logfname)
                 # STEP 3
@@ -3419,6 +3423,9 @@ class PolarizableTyper():
                 foundendgau=False # sometimes gaussian comments have keyword Error, ERROR in them
                 foundhf=False
                 # STEP 4
+                print('')
+                print('')
+                print(tail)
                 for line in open(logfname):
                     if 'poltype' in tail:
                         if 'Poltype Job Finished' in line:
@@ -3427,10 +3434,13 @@ class PolarizableTyper():
                             error=True
                     else:
                         if "Final optimized geometry" in line or "Electrostatic potential computed" in line or 'Psi4 exiting successfully' in line or "LBFGS  --  Normal Termination due to SmallGrad" in line or "Normal termination" in line or 'Normal Termination' in line or 'Total Potential Energy' in line or 'Psi4 stopped on' in line or 'finished run' in line or ('Converged! =D' in line):
+                            print(line)
                             term=True
-                        if ('Tinker is Unable to Continue' in line or 'error' in line or ' Error ' in line or ' ERROR ' in line or 'impossible' in line or 'software termination' in line or 'segmentation violation, address not mapped to object' in line or 'galloc:  could not allocate memory' in line or 'Erroneous write.' in line or 'Optimization failed to converge!' in line) and 'DIIS' not in line and 'mpi' not in line and 'RMS Error' not in line:
+                        if ('Tinker is Unable to Continue' in line or 'error' in line or ' Error ' in line or ' ERROR ' in line or 'impossible' in line or 'software termination' in line or 'segmentation violation, address not mapped to object' in line or 'galloc:  could not allocate memory' in line or 'Erroneous write.' in line or 'Optimization failed to converge!' in line or 'Geometry optimization is not converged' in line or 'Error' in line) and 'DIIS' not in line and 'mpi' not in line and 'RMS Error' not in line:
                             error=True
                             errorline=line
+                            print('')
+                            print(errorline)
                         if 'segmentation violation' in line and 'address not mapped to object' not in line or 'Waiting' in line or ('OptimizationConvergenceError' in line and 'except' in line) or "Error on total polarization charges" in line or 'Erroneous write' in line:
                             error=False
                             continue
@@ -3530,7 +3540,13 @@ class PolarizableTyper():
                     # STEP 1
                     self.WriteToLog("Submitting: " + cmdstr+' '+'path'+' = '+os.getcwd())
                     # STEP 2
-                    p = subprocess.Popen(cmdstr,shell=True,stdout=self.logfh, stderr=self.logfh)
+                    if 'pyscf' in cmdstr:
+                        out = cmdstr.split()[-1]
+                        out_pyscf = open(out, 'w')
+                        p = subprocess.Popen(cmdstr,shell=True,stdout=out_pyscf, stderr=out_pyscf)
+                    else:
+                        p = subprocess.Popen(cmdstr,shell=True,stdout=self.logfh, stderr=self.logfh)
+
                     procs.append(p)
                     self.cmdtopid[cmdstr]=p
 
@@ -5891,6 +5907,7 @@ class PolarizableTyper():
             else:
                 # STEP 3
                 for path in os.environ["PATH"].split(os.pathsep):
+                    print(path)
                     exe_file = os.path.join(path, program)
                     result=is_exe(exe_file)
                     if result:

--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -456,6 +456,9 @@ class PolarizableTyper():
         espbasisset:str="aug-cc-pVTZ"
         torspbasisset:str="6-311+G*"
         optmethod:str='MP2'
+        pyscf_opt_meth:str = 'wb97x_d3'
+        pyscf_sol_imp:str = 'IEF-PCM' # C-PCM, SS(V)PE, COSMO
+        pyscf_sol_eps:float = 78.3553 # Water
         toroptmethod:str='xtb'
         torspmethod:str='wB97X-D'
         dmamethod:str='MP2'
@@ -1189,6 +1192,12 @@ class PolarizableTyper():
                                     warnings.warn(f"Could not locate prmmod file '{fpath1}'")
                         elif newline.startswith("optmethod"):
                             self.optmethod = a
+                        elif newline.startswith("pyscf_opt_met"):
+                            self.pyscf_opt_met = a
+                        elif newline.startswith("pyscf_sol_imp"):
+                            self.pyscf_sol_imp = a
+                        elif newline.startswith("pyscf_sol_eps"):
+                            self.pyscf_sol_eps = a
                         elif newline.startswith("espmethod"):
                             self.espmethod = a
                         elif "torspmethod" in newline:
@@ -3373,11 +3382,12 @@ class PolarizableTyper():
             5. If error occured, write out line containing error to poltype log file.
             6. xtb only outputs the same filename for optimization jobs, so be sure to copy to desired filename after job finishes. 
             """
-
+            
             ###########
-            # TM: Need to add checks for proper and improper termination of 
+            # TM: Need to add checks for proper and improper termination of
             # PySCF job
             ##########
+
 
             error=False
             term=False
@@ -4743,6 +4753,9 @@ class PolarizableTyper():
             self.localframe1 = [ 0 ] * mol.NumAtoms()
             self.localframe2 = [ 0 ] * mol.NumAtoms()
             self.WriteToLog("Atom Type Classification")
+            self.WriteToLog('Poltype image build time: ')
+            self.WriteToLog('Tinker commit: c9698d2101c5f66ce1d413f4aa2d5f62e4c22df2')
+            self.WriteToLog('Poltype commit: 51b235f8f0af0975c9afae789f671d698b44d7e5')
             self.idxtosymclass,self.symmetryclass=symm.gen_canonicallabels(self,mol,None,self.usesymtypes,True)
             # STEP 15
             torgen.FindPartialDoubleBonds(self,m,mol) # need to find something to hardcode transfer for partial double amide/acid, currently will derive torsion parameters if doesnt find "good" match in torsion database

--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -5174,6 +5174,9 @@ class PolarizableTyper():
                 shutil.copy(self.xyzfname,self.xyzoutfile)
             shutil.copy(self.xyzoutfile,self.tmpxyzfile)
             shutil.copy(self.key7fname,self.tmpkeyfile)
+
+            shutil.copy(self.key7fname,'TEST_tim.key')
+            
             # STEP 51
             if self.writeoutpolarize and self.writeoutmultipole==True:
                 opt.StructureMinimization(self,torsionrestraints)

--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -3373,6 +3373,12 @@ class PolarizableTyper():
             5. If error occured, write out line containing error to poltype log file.
             6. xtb only outputs the same filename for optimization jobs, so be sure to copy to desired filename after job finishes. 
             """
+
+            ###########
+            # TM: Need to add checks for proper and improper termination of 
+            # PySCF job
+            ##########
+
             error=False
             term=False
             lastupdatetofilename={}

--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -3383,12 +3383,6 @@ class PolarizableTyper():
             6. xtb only outputs the same filename for optimization jobs, so be sure to copy to desired filename after job finishes. 
             """
             
-            ###########
-            # TM: Need to add checks for proper and improper termination of
-            # PySCF job
-            ##########
-
-
             error=False
             term=False
             lastupdatetofilename={}
@@ -3409,10 +3403,6 @@ class PolarizableTyper():
             os.chdir(curdir)
             # STEP 2
             htime=min(lastupdatetofilename.keys())
-            print('')
-            print('')
-            print('########')
-            print(logfname)
             if os.path.isfile(logfname):
                 head,tail=os.path.split(logfname)
                 # STEP 3
@@ -3423,9 +3413,6 @@ class PolarizableTyper():
                 foundendgau=False # sometimes gaussian comments have keyword Error, ERROR in them
                 foundhf=False
                 # STEP 4
-                print('')
-                print('')
-                print(tail)
                 for line in open(logfname):
                     if 'poltype' in tail:
                         if 'Poltype Job Finished' in line:
@@ -3434,13 +3421,10 @@ class PolarizableTyper():
                             error=True
                     else:
                         if "Final optimized geometry" in line or "Electrostatic potential computed" in line or 'Psi4 exiting successfully' in line or "LBFGS  --  Normal Termination due to SmallGrad" in line or "Normal termination" in line or 'Normal Termination' in line or 'Total Potential Energy' in line or 'Psi4 stopped on' in line or 'finished run' in line or ('Converged! =D' in line):
-                            print(line)
                             term=True
                         if ('Tinker is Unable to Continue' in line or 'error' in line or ' Error ' in line or ' ERROR ' in line or 'impossible' in line or 'software termination' in line or 'segmentation violation, address not mapped to object' in line or 'galloc:  could not allocate memory' in line or 'Erroneous write.' in line or 'Optimization failed to converge!' in line or 'Geometry optimization is not converged' in line or 'Error' in line) and 'DIIS' not in line and 'mpi' not in line and 'RMS Error' not in line:
                             error=True
                             errorline=line
-                            print('')
-                            print(errorline)
                         if 'segmentation violation' in line and 'address not mapped to object' not in line or 'Waiting' in line or ('OptimizationConvergenceError' in line and 'except' in line) or "Error on total polarization charges" in line or 'Erroneous write' in line:
                             error=False
                             continue
@@ -5907,7 +5891,6 @@ class PolarizableTyper():
             else:
                 # STEP 3
                 for path in os.environ["PATH"].split(os.pathsep):
-                    print(path)
                     exe_file = os.path.join(path, program)
                     result=is_exe(exe_file)
                     if result:

--- a/PoltypeModules/pyscf_for_frag.py
+++ b/PoltypeModules/pyscf_for_frag.py
@@ -53,4 +53,26 @@ def read_frag_opt(poltype,outputlog,mol):
     
     Opt_post = PySCF_post_run(poltype,os.getcwd(),outputlog,mol)
 
-    Opt_post.read_out() 
+    Opt_post.read_out()
+
+
+def setup_frag_sp(poltype,inputmol,inputstruc,pre):
+
+    charge = inputmol.GetTotalCharge()
+    print('In setup_frag_sp')
+    print(pre)
+    print(inputstruc)
+    print(charge)
+
+    Opt_prep = PySCF_init_setup(poltype,os.getcwd(),pre,inputmol,\
+                               False,charge)
+
+
+    Opt_prep.PySCF_inp_xyz = inputstruc
+    Opt_prep.write_PySCF_input(False,True)
+
+
+    cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} &> {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
+
+    return Opt_prep.PySCF_inp_file,Opt_prep.PySCF_out_file,cmd
+ 

--- a/PoltypeModules/pyscf_for_frag.py
+++ b/PoltypeModules/pyscf_for_frag.py
@@ -8,20 +8,9 @@ def setup_frag_opt(poltype,newtorset,toranglelist,\
 
     
     charge = inputmol.GetTotalCharge()
-    print('In setup_frag_opt')
-    print(newtorset)
-    print(toranglelist)
-    print(pre)
-    print(inputname)
-    print(inputstruc)
-    print(charge)
 
     Opt_prep = PySCF_init_setup(poltype,os.getcwd(),pre,inputmol,\
                                False,charge)
-
-    #Opt_prep.read_Tinker_inp_coord()
-
-    #Opt_prep.write_xyz('init') 
 
     Opt_prep.PySCF_inp_xyz = inputstruc
 
@@ -32,21 +21,6 @@ def setup_frag_opt(poltype,newtorset,toranglelist,\
     cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} &> {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
 
     return Opt_prep.PySCF_inp_file,Opt_prep.PySCF_out_file,cmd
-
-    #cmd_to_run = {cmd: f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'}
-
-    #if os.path.isfile(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'):
-    #    os.remove(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}')
-
-
-    #if poltype.externalapi==None:
-    #    #Temporary fix to work on CheckNormalTermination
-    #    #if os.path.isfile(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'):
-    #    #    pass
-    #    #else:
-    #    finishedjobs,errorjobs=poltype.CallJobsSeriallyLocalHost(cmd_to_run,False)
-    #    print(f'Optimization for Frag {Opt_prep.PySCF_inp_file}')
-    #    print(finishedjobs,errorjobs)
 
 
 def read_frag_opt(poltype,outputlog,mol):
@@ -59,14 +33,9 @@ def read_frag_opt(poltype,outputlog,mol):
 def setup_frag_sp(poltype,inputmol,inputstruc,pre):
 
     charge = inputmol.GetTotalCharge()
-    print('In setup_frag_sp')
-    print(pre)
-    print(inputstruc)
-    print(charge)
 
     Opt_prep = PySCF_init_setup(poltype,os.getcwd(),pre,inputmol,\
                                False,charge)
-
 
     Opt_prep.PySCF_inp_xyz = inputstruc
     Opt_prep.write_PySCF_input(False,True)

--- a/PoltypeModules/pyscf_for_frag.py
+++ b/PoltypeModules/pyscf_for_frag.py
@@ -16,15 +16,41 @@ def setup_frag_opt(poltype,newtorset,toranglelist,\
     print(inputstruc)
     print(charge)
 
-    Opt_prep = PySCF_init_setup(poltype,os.getcwd(),inputstruc,inputmol,\
+    Opt_prep = PySCF_init_setup(poltype,os.getcwd(),pre,inputmol,\
                                False,charge)
 
     #Opt_prep.read_Tinker_inp_coord()
 
     #Opt_prep.write_xyz('init') 
 
-    Opt_prep.PySCF_inp_xyz = Opt_prep.init_data['COM_file']
+    Opt_prep.PySCF_inp_xyz = inputstruc
 
     Opt_prep.write_geometric_tor_const(pre,newtorset)
 
     Opt_prep.write_PySCF_input(True,True)
+
+    cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} &> {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
+
+    return Opt_prep.PySCF_inp_file,Opt_prep.PySCF_out_file,cmd
+
+    #cmd_to_run = {cmd: f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'}
+
+    #if os.path.isfile(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'):
+    #    os.remove(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}')
+
+
+    #if poltype.externalapi==None:
+    #    #Temporary fix to work on CheckNormalTermination
+    #    #if os.path.isfile(f'{Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'):
+    #    #    pass
+    #    #else:
+    #    finishedjobs,errorjobs=poltype.CallJobsSeriallyLocalHost(cmd_to_run,False)
+    #    print(f'Optimization for Frag {Opt_prep.PySCF_inp_file}')
+    #    print(finishedjobs,errorjobs)
+
+
+def read_frag_opt(poltype,outputlog,mol):
+    
+    Opt_post = PySCF_post_run(poltype,os.getcwd(),outputlog,mol)
+
+    Opt_post.read_out() 

--- a/PoltypeModules/pyscf_for_frag.py
+++ b/PoltypeModules/pyscf_for_frag.py
@@ -1,0 +1,30 @@
+# Import both PySCF setup class
+from pyscf_setup import PySCF_init_setup
+from pyscf_setup import PySCF_post_run
+import os
+
+def setup_frag_opt(poltype,newtorset,toranglelist,\
+                    pre,inputmol,inputname,inputstruc):
+
+    
+    charge = inputmol.GetTotalCharge()
+    print('In setup_frag_opt')
+    print(newtorset)
+    print(toranglelist)
+    print(pre)
+    print(inputname)
+    print(inputstruc)
+    print(charge)
+
+    Opt_prep = PySCF_init_setup(poltype,os.getcwd(),inputstruc,inputmol,\
+                               False,charge)
+
+    #Opt_prep.read_Tinker_inp_coord()
+
+    #Opt_prep.write_xyz('init') 
+
+    Opt_prep.PySCF_inp_xyz = Opt_prep.init_data['COM_file']
+
+    Opt_prep.write_geometric_tor_const(pre,newtorset)
+
+    Opt_prep.write_PySCF_input(True,True)

--- a/PoltypeModules/pyscf_for_frag.py
+++ b/PoltypeModules/pyscf_for_frag.py
@@ -5,42 +5,101 @@ import os
 
 def setup_frag_opt(poltype,newtorset,toranglelist,\
                     pre,inputmol,inputname,inputstruc):
-
     
+    """
+    This function setup the PySCF file to do
+    a geometry optimization.
+
+    Inputs:
+        -   poltype: poltype class object (class obj)
+        -   newtorset: list of torsion to restrain (list of list)
+        -   toranglelist: list of torsion angle to restrain (list of float)
+        -   pre: prefix name (string)
+        -   inputmol: molecule object (babel or rdkit mol obj)
+        -   inputname: name of the input file (string)
+        -   inputstruc: name if the file with input geometry (string)
+
+    Outputs:
+        -   Opt_prep.PySCF_inp_file: Name of PySCF input file
+        -   Opt_prep.PySCF_out_file: Name of PySCF output file
+        -   cmd: command to run        
+
+    """
+
+    # Define the charge of the molecule 
     charge = inputmol.GetTotalCharge()
 
+    # Instantiate the PySCF initial setup object
     Opt_prep = PySCF_init_setup(poltype,os.getcwd(),pre,inputmol,\
                                False,charge)
 
+    # Define the input geometry file
     Opt_prep.PySCF_inp_xyz = inputstruc
 
+    # Write the geometric constrain file
     Opt_prep.write_geometric_tor_const(pre,newtorset)
 
+    # Write the PySCF input file: is_opt = True, is_frag = True
     Opt_prep.write_PySCF_input(True,True)
 
+    # Define the command to run
     cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} &> {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
 
     return Opt_prep.PySCF_inp_file,Opt_prep.PySCF_out_file,cmd
 
 
 def read_frag_opt(poltype,outputlog,mol):
+   
+    """
+    This function creates the post run PySCf object and
+    reads the optimized geometry
     
+    Inputs:
+        -   poltype: poltype class object (class obj)
+        -   outputlog: Name of the output file (string)
+        -   mol: molecule object (babel or rdkit mol obj)
+
+    """
+
+    # Instantiate the PySCF post run class 
     Opt_post = PySCF_post_run(poltype,os.getcwd(),outputlog,mol)
 
+    # Read and create the optimized geometry file
     Opt_post.read_out()
 
 
 def setup_frag_sp(poltype,inputmol,inputstruc,pre):
 
+    """
+    This function set up the fragment SP calculation
+
+    Inputs:
+        -   poltype: poltype class object (class obj)
+        -   inputmol: molecule object (babel or rdkit mol obj)
+        -   inputstruc: name if the file with input geometry (string)
+        -   pre: prefix name (string)
+
+    Outputs:
+        -   Opt_prep.PySCF_inp_file: Name of PySCF input file
+        -   Opt_prep.PySCF_out_file: Name of PySCF output file
+        -   cmd: command to run        
+
+    """
+
+    # Define the charge of the molecule
     charge = inputmol.GetTotalCharge()
 
+    # Instantiate the PySCF initial setup object 
     Opt_prep = PySCF_init_setup(poltype,os.getcwd(),pre,inputmol,\
                                False,charge)
 
+    # Define the input geometry file
     Opt_prep.PySCF_inp_xyz = inputstruc
+
+    # Write the PySCF input file: is_opt = False, is_frag = True
     Opt_prep.write_PySCF_input(False,True)
 
-
+    # Define the command to run
     cmd = f'python {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_inp_file} &> {Opt_prep.init_data["topdir"]}/{Opt_prep.PySCF_out_file}'
 
     return Opt_prep.PySCF_inp_file,Opt_prep.PySCF_out_file,cmd

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -59,6 +59,7 @@ class PySCF_init_setup():
     def write_PySCF_input(self):
 
         self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py" 
+        self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.out" 
 
         self.write_PySCF_header()
 

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -78,8 +78,8 @@ class PySCF_init_setup():
     def write_PySCF_input(self,is_opt=True,is_frag=False):
 
         if is_frag:
-            self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.xyz')}.py"
-            self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.xyz')}_pyscf.log" 
+            self.PySCF_inp_file = f"{self.init_data['COM_file']}.py"
+            self.PySCF_out_file = f"{self.init_data['COM_file']}_pyscf.log" 
         else:
             self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py"
             self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.log" 

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -39,8 +39,6 @@ class PySCF_init_setup():
             next(f)
             for lines in f:
                 L = lines.strip('\n').split()
-                #print(L)
-                #if len(L)==4 and '#' not in L:
                 self.mol_data_init['Atoms_list'].append(L[0])
                 self.mol_data_init['Atoms_coord'].append([float(i) for i in L[1:]])
 
@@ -124,10 +122,7 @@ class PySCF_init_setup():
 
     def write_PySCF_main(self,is_opt,is_frag):
 
-        print('in PySCF main')
-
         atm_s = f'atom="{self.PySCF_inp_xyz}"'
-        print(self.PySCF_inp_file)
         if is_opt:
             if not is_frag:
                 basis_s = f'basis = "{self.pol_obj.optbasisset}"'
@@ -146,11 +141,6 @@ class PySCF_init_setup():
         else:
             chg_s = f'charge = {self.mol_data_init["charge"]}'
         unit_s = 'unit = "A"'
-
-        print(atm_s)
-        print(basis_s)
-        print(spin_s)
-        print(unit_s)
 
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
             f.write(f'mol = pyscf.M({atm_s}, {basis_s}, {spin_s}, {chg_s}, {unit_s})\n')
@@ -171,7 +161,6 @@ class PySCF_init_setup():
                 f.write('mol_sp = mf.kernel()\n')
                 f.write('print(f"Final Energy: {mol_sp}")\n')
                 f.write('print("Normal Termination")\n')
-                print('Need to add code for PySCF sp')
 
 
     

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -3,6 +3,27 @@ import os
 
 class PySCF_init_setup():
 
+    """
+    This class corresponds to the initial setup
+    of a PySCF calculation.
+
+    It reads a geometry and prepare the pyscf input file,
+    torsion restraints and final output.
+    
+    !!!! WARNING !!!
+    You need to make sure that pyscf version is 2.7.0 to use wb97x-d3 !!
+
+    Inputs:
+        -   poltype_obj: poltype class object (class obj)
+        -   cure_dir: path for the current directory (string)
+        -   COM_file: initial file name (string)
+        -   mol: molecule object (babel or rdkit mol obj)
+        -   skip_error: Skip or not the errors when checking for failures (bool)
+        -   charge: charge of the molecule (None or int)
+        
+
+    """
+
     def __init__(self,poltype_obj,cure_dir,COM_file,mol,\
                  skip_error,charge):
 
@@ -14,12 +35,22 @@ class PySCF_init_setup():
         self.mol_data_init = {'charge': charge}
 
 
-    
-
     def read_Gauss_inp_coord(self):
 
+        """
+        This function reads the intitial coordinate from a gaussian 
+        input file. 
+        This is one is used only when running the optimization of the
+        parent ligand.
+        The coordinate and atom list are saved in two lists.
+    
+        """
+    
+        # Initialize the atom list and coordinate
         self.mol_data_init['Atoms_list'] = []
         self.mol_data_init['Atoms_coord'] = []
+
+        # Loop through the gaussian file and grab the coordinates
         with open(f"{self.init_data['topdir']}/{self.init_data['COM_file']}", 'r') as f:
             for lines in f:
                 L = lines.strip('\n').split()
@@ -27,13 +58,23 @@ class PySCF_init_setup():
                     self.mol_data_init['Atoms_list'].append(L[0])
                     self.mol_data_init['Atoms_coord'].append([float(i) for i in L[1:]])
 
-
         return
+
 
     def read_Tinker_inp_coord(self):
 
+        """
+        This function reads the coordinate from a Tinker xyz file.
+        This function is used when the torsion scan is being done.
+        The coordinate and atom list are saved in two lists.
+
+        """
+
+        # Initialize the atom list and coordinate
         self.mol_data_init['Atoms_list'] = []
         self.mol_data_init['Atoms_coord'] = []
+
+        # Loop through the tinker xyz file and grab the coordinates
         with open(f"{self.init_data['topdir']}/{self.init_data['COM_file']}", 'r') as f:
             next(f)
             next(f)
@@ -42,14 +83,26 @@ class PySCF_init_setup():
                 self.mol_data_init['Atoms_list'].append(L[0])
                 self.mol_data_init['Atoms_coord'].append([float(i) for i in L[1:]])
 
-
         return
 
 
     def write_xyz(self,name):
 
+        """
+        This function writes a standard xyz file to be used as 
+        input geometry for PySCF.
+        The coordinates are taken from either a Gaussian .com 
+        or tinker xyz file.
+
+        Inputs:
+            -   name: Name to give to the xyz file to be written (string)
+
+        """
+
+        # Define the PySCF input xyz file name
         self.PySCF_inp_xyz = f"{self.init_data['COM_file'].strip('.com')}_{name}.xyz"
 
+        # Write the xyz file
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_xyz}", 'w') as f:
             f.write(f"{len(self.mol_data_init['Atoms_coord'])}\n\n")
             for A,C in zip(self.mol_data_init['Atoms_list'],self.mol_data_init['Atoms_coord']):
@@ -57,10 +110,25 @@ class PySCF_init_setup():
 
         return
 
+
     def write_geometric_tor_const(self,name,tor_const, tor_angle=None):
 
+        """
+        This function writes the torsion constraint file in the 
+        GeomeTRIC file format. This file is being used by PySCF.
+
+        Inputs:
+            -   name: Name to give to the constraint file to be written (string)
+            -   tor_const: the torsion atom index to be constrained (list of list)
+            -   tor_angle: torsion angle to constrained (list of float)
+
+        """
+
+        # Define the PySCF constraint file name
         self.PySCF_inp_const = f"PySCF_{name}_constraint.txt"
 
+        # Write the constraint file using the given torsion index
+        # and tor angle, or by calculting it
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_const}", 'w') as f:
             f.write('$set\n')
             for i,tor in enumerate(tor_const):
@@ -75,8 +143,26 @@ class PySCF_init_setup():
 
     def write_PySCF_input(self,is_opt=True,is_frag=False):
 
+        """
+        This function writes the PySCF input file.
+        The input depends on: 
+            - Is the molecule the parent ligand or a fragment
+            - Is it an optimization or single point
+
+        Inputs:
+            -   is_opt: is it an optimization (bool)
+            -   is_frag: is the molecule a fragment (bool)
+
+        """
+
+        # If the molecule us a fragment
         if is_frag:
+
+            # Need to add pyscf in the input file name to make sure
+            # that it is properly submitted per poltype.call_subsystem
             self.PySCF_inp_file = f"{self.init_data['COM_file']}_pyscf.py"
+
+            # Remove pyscf in the log name for SP calculation 
             if is_opt:
                 self.PySCF_out_file = f"{self.init_data['COM_file']}_pyscf.log"
             else:
@@ -85,15 +171,33 @@ class PySCF_init_setup():
             self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.py"
             self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.log" 
 
+        # Write the PySCF header
         self.write_PySCF_header(is_opt)
 
+        # If it is a geometry optimization
+        # Write the PySCF params part
         if is_opt:
             self.write_PySCF_params()
 
+        # Write the main core of the PySCF script
         self.write_PySCF_main(is_opt,is_frag)
+
+        return
+
 
     def write_PySCF_header(self,is_opt):
 
+        """
+        This function writes the header in the PySCF input file.
+        It only writes the library import
+
+        Inputs:
+            -   is_opt: is it an optimization (bool)
+            
+        """
+
+        # Write the header part with all the import needed
+        # If it not an optimization, no need to import optimize
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'w') as f:
             f.write('import pyscf\n')
             f.write('from pyscf import gto, scf\n')
@@ -104,8 +208,20 @@ class PySCF_init_setup():
 
         return
 
+
     def write_PySCF_params(self):
 
+        """
+        This function writes the PySCF parameters needed
+        to pass to GeomeTRIC. 
+        It gives the contraints file and the convergence criteria
+
+        @Chengwen: For now I only setup LOOSE for the convergence criteria
+        But we might want to change that!
+    
+        """
+
+        # Write the params to pass to GeomeTRIC
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
             f.write('params = {\n')
             f.write(f'"constraints": "{self.PySCF_inp_const}",\n')
@@ -115,14 +231,30 @@ class PySCF_init_setup():
                 f.write('            "convergence_gmax": 2.5e-3,\n') 
                 f.write('            "convergence_drms": 6.7e-3,\n') 
                 f.write('            "convergence_dmax": 1.0e-2,\n') 
-
-            f.write('}\n\n') 
+            f.write('}\n\n')
+ 
         return 
 
 
     def write_PySCF_main(self,is_opt,is_frag):
 
+        """
+        This function writes the main part of the PySCF script.
+
+        @Chengwen: For now I used the same function for both OPT and SP. 
+        We might want to have one variable for OPT and one for SP
+
+        Inputs:
+            -   is_opt: is it an optimization (bool)
+            -   is_frag: is the molecule a fragment (bool) 
+
+        """
+
+        # Define the atom string == input geometry
         atm_s = f'atom="{self.PySCF_inp_xyz}"'
+
+        # Define the basis string == basis used for QM
+        # It is using the same basis as for Psi in gas phase
         if is_opt:
             if not is_frag:
                 basis_s = f'basis = "{self.pol_obj.optbasisset}"'
@@ -132,39 +264,71 @@ class PySCF_init_setup():
             if is_frag:
                 basis_s = f'basis = "{self.pol_obj.torspbasisset}"'
             else:
-                raise Warning('PySCF is not set up to run PCM single point QM for parent ligand')
+                self.pol_obj.WriteToLog('PySCF is not set up to run PCM single point QM for parent ligand\n Talk to a developer\n\n')
+                raise Exception('PySCF is not set up to run PCM single point QM for parent ligand\n Talk to a developer\n\n')
                 
-
+        # Define the spin string == multiplicity of the molecule (2S in PySCF)
         spin_s = f'spin = {int(self.mol_obj.GetTotalSpinMultiplicity())-1}'
+
+        # Define the charge string == charge of the molecule 
+        # Either given as input or determine with mol object
         if self.mol_data_init['charge'] == None:
             chg_s = f'charge = {self.mol_obj.GetTotalCharge()}'
         else:
             chg_s = f'charge = {self.mol_data_init["charge"]}'
+
+        # Define the unit string for the geometry (always A so far)
         unit_s = 'unit = "A"'
 
+        # Write the main part of the input file
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
+
+            # Define the molecule and build it
             f.write(f'mol = pyscf.M({atm_s}, {basis_s}, {spin_s}, {chg_s}, {unit_s})\n')
             f.write('mol.build()\n')
+
+            # For now use the same DFT functional for both fragment and parent
+            # ligand
             if not is_frag:
                 f.write(f'mf = pyscf.solvent.PCM(mol.UKS(xc = "{self.pol_obj.pyscf_opt_meth}").density_fit())\n')
             else:
                 f.write(f'mf = pyscf.solvent.PCM(mol.UKS(xc = "{self.pol_obj.pyscf_opt_meth}").density_fit())\n')
-                
+            
+            # Define the solvent part 
             f.write(f'mf.with_solvent.method = "{self.pol_obj.pyscf_sol_imp}"\n')
             f.write(f'mf.with_solvent.eps = {self.pol_obj.pyscf_sol_eps}\n\n')
+
+            # Define the optimization part
             if is_opt:
                 f.write(f'mol_eq = optimize(mf, maxsteps={self.pol_obj.optmaxcycle}, **params)\n')
                 f.write('print(f"Final optimized structure:")\n')
                 f.write('print(mol_eq.tostring())\n\n')
-                
+            
+            # Define the single point part
+            # "Normal Termination" in added in PySCF output to ensure that
+            # poltype.CheckNormalTermination can correctly process good termination 
             else:
                 f.write('mol_sp = mf.kernel()\n')
                 f.write('print(f"Final Energy: {mol_sp}")\n')
                 f.write('print("Normal Termination")\n')
-
+        return
 
     
 class PySCF_post_run():
+
+    """
+    This class corresponds to the PySCF post run analysis.
+    For now, it only grabs the optimized geometry.
+    The SP energy grab is done in torsionfit.py file
+
+    Inputs:
+        -   poltype_obj: poltype class object (class obj)
+        -   cure_dir: path for the current directory (string)
+        -   output_file: name of the pyscf outptu file (string)
+        -   mol_obj: molecule object (babel or rdkit mol obj)
+
+    """
+
 
     def __init__(self,poltype_obj,cure_dir,output_file,mol_obj):
 
@@ -176,11 +340,20 @@ class PySCF_post_run():
 
     def read_out(self):
 
-        val = subprocess.check_output(f"grep -A {self.mol_obj.NumAtoms()} 'Final optimized structure' {self.topdir}/{self.out_file}",shell=True)
+        """
+        This function reads the optimized structure in the 
+        PySCF output file and write in a standard xyz format
 
+        """
+
+        # Use grep to get the optimized geometry
+        val = subprocess.check_output(f"grep -A {self.mol_obj.NumAtoms()} 'Final optimized structure' {self.topdir}/{self.out_file}",shell=True)
         Geom = val.decode("utf-8").split()
+
+        # Define the final optimized xyz file 
         self.final_opt_xyz = f"{self.out_file.split('.log')[0]}.xyz"
 
+        # Write the optimized coordinate
         start = 3
         with open(f'{self.topdir}/{self.final_opt_xyz}', 'w') as file_1:
             file_1.write(f'{self.mol_obj.NumAtoms()}\n\n')

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -1,0 +1,118 @@
+
+
+
+class PySCF_init_setup():
+
+    def __init__(self,poltype_obj,cure_dir,COM_file,mol,\
+                 modred,b_a_restraint,skip_error,charge,\
+                 opt_conv,torsion_restraints):
+
+        self.pol_obj = poltype_obj
+        self.mol_obj = mol
+        self.init_data = {'topdir': cure_dir, 'COM_file': COM_file,
+                          'modred': modred,'b_a_rest': b_a_restraint,
+                          'skip_error': skip_error,'opt_conv': opt_conv,
+                          'tor_rest': torsion_restraints}
+        self.mol_data_init = {'charge': charge}
+
+
+    
+
+    def read_Gauss_inp_coord(self):
+
+        self.mol_data_init['Atoms_list'] = []
+        self.mol_data_init['Atoms_coord'] = []
+        with open(f"{self.init_data['topdir']}/{self.init_data['COM_file']}", 'r') as f:
+            for lines in f:
+                L = lines.strip('\n').split()
+                if len(L)==4 and '#' not in L:
+                    self.mol_data_init['Atoms_list'].append(L[0])
+                    self.mol_data_init['Atoms_coord'].append([float(i) for i in L[1:]])
+
+
+        return
+
+    def write_xyz(self,name):
+
+        self.PySCF_inp_xyz = f"{self.init_data['COM_file'].strip('.com')}_{name}.xyz"
+
+        with open(f"{self.init_data['topdir']}/{self.PySCF_inp_xyz}", 'w') as f:
+            f.write(f"{len(self.mol_data_init['Atoms_coord'])}\n\n")
+            for A,C in zip(self.mol_data_init['Atoms_list'],self.mol_data_init['Atoms_coord']):
+                f.write(f'{A:3s} {C[0]:9.6f} {C[1]:9.6f} {C[2]:9.6f}\n')
+
+        return
+
+    def write_geometric_tor_const(self,name):
+
+        self.PySCF_inp_const = f"PySCF_{name}_constraint.txt"
+
+        with open(f"{self.init_data['topdir']}/{self.PySCF_inp_const}", 'w') as f:
+            f.write('$set\n')
+            for tor in self.init_data['tor_rest']:
+                angle = self.mol_obj.GetTorsion(tor[0], tor[1], tor[2], tor[3]) % 360
+                f.write(f'dihedral {tor[0]} {tor[1]} {tor[2]} {tor[3]} {angle:3.4f}\n')
+
+        return
+
+
+    def write_PySCF_input(self):
+
+        self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py" 
+
+        self.write_PySCF_header()
+
+        self.write_PySCF_params()
+
+        self.write_PySCF_main()
+
+    def write_PySCF_header(self):
+
+        with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'w') as f:
+            f.write('import pyscf\n')
+            f.write('from pyscf import gto, scf\n')
+            f.write('from pyscf.dft import rks,uks\n')
+            f.write('from pyscf import dft\n')
+            f.write('from pyscf.geomopt.geometric_solver import optimize\n\n')
+
+        return
+
+    def write_PySCF_params(self):
+
+        with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
+            f.write(f'params = {{"constraints": "{self.PySCF_inp_const}",\n')
+            if self.pol_obj.optconvergence == 'LOOSE':
+                f.write('            "convergence_energy": 1e-4,\n') 
+                f.write('            "convergence_grms": 1.7e-3,\n') 
+                f.write('            "convergence_gmax": 2.5e-3,\n') 
+                f.write('            "convergence_drms": 6.7e-3,\n') 
+                f.write('            "convergence_dmax": 1.0e-2,\n') 
+
+            f.write('}\n\n') 
+        return 
+
+
+    def write_PySCF_main(self):
+
+        atm_s = f'atom="{self.PySCF_inp_xyz}"'
+        basis_s = f'basis = "{self.pol_obj.optbasisset}"'
+        spin_s = f'spin = {int(self.mol_obj.GetTotalSpinMultiplicity())-1}'
+        if self.mol_data_init['charge'] == None:
+            chg_s = f'charge = {self.mol_obj.GetTotalCharge()}'
+        else:
+            chg_s = f'charge = {self.mol_data_init["charge"]}'
+        unit_s = 'unit = "A"'
+
+        with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
+            f.write(f'mol = pyscf.M({atm_s}, {basis_s}, {spin_s}, {chg_s}, {unit_s})\n')
+            f.write('mol.build()\n')
+            f.write(f'mf = pyscf.solvent.PCM(mol.UKS(xc = "{self.pol_obj.pyscf_opt_meth}").density_fit())\n')
+            f.write(f'mf.with_solvent.method = "{self.pol_obj.pyscf_sol_imp}"\n')
+            f.write(f'mf.with_solvent.eps = {self.pol_obj.pyscf_sol_eps}\n\n')
+            f.write(f'mol_eq = optimize(mf, maxsteps={self.pol_obj.optmaxcycle}, **params)\n')
+            f.write('print(f"Final optimized structure:")\n')
+            f.write('print(mol_eq.tostring())\n\n')
+
+
+    
+

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -1,5 +1,5 @@
-
-
+import subprocess
+import os
 
 class PySCF_init_setup():
 
@@ -59,7 +59,7 @@ class PySCF_init_setup():
     def write_PySCF_input(self):
 
         self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py" 
-        self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.out" 
+        self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.log" 
 
         self.write_PySCF_header()
 
@@ -116,4 +116,34 @@ class PySCF_init_setup():
 
 
     
+class PySCF_post_run():
+
+    def __init__(self,poltype_obj,cure_dir,output_file,mol_obj):
+
+        self.pol_obj = poltype_obj
+        self.topdir = cure_dir
+        self.out_file = output_file
+        self.mol_obj = mol_obj
+
+
+    def read_out(self):
+
+        val = subprocess.check_output(f"grep -A {self.mol_obj.NumAtoms()} 'Final optimized structure' {self.topdir}/{self.out_file}",shell=True)
+
+        Geom = val.decode("utf-8").split()
+        self.final_opt_xyz = f"{self.out_file.split('.log')[0]}.xyz"
+
+        cc = 0
+        start = 3
+
+
+        with open(f'{self.topdir}/{self.final_opt_xyz}', 'w') as file_1:
+            file_1.write(f'{self.mol_obj.NumAtoms()}\n\n')
+            for i in range(0,len(Geom[3:]),4):
+                end = start + 4
+                file_1.write(f'{" ".join([j for j in Geom[start:end]])}\n')
+                start = end
+        
+ 
+
 

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -4,15 +4,13 @@ import os
 class PySCF_init_setup():
 
     def __init__(self,poltype_obj,cure_dir,COM_file,mol,\
-                 modred,b_a_restraint,skip_error,charge,\
-                 opt_conv,torsion_restraints):
+                 skip_error,charge):
 
         self.pol_obj = poltype_obj
         self.mol_obj = mol
         self.init_data = {'topdir': cure_dir, 'COM_file': COM_file,
-                          'modred': modred,'b_a_rest': b_a_restraint,
-                          'skip_error': skip_error,'opt_conv': opt_conv,
-                          'tor_rest': torsion_restraints}
+                          'skip_error': skip_error,
+                          }
         self.mol_data_init = {'charge': charge}
 
 
@@ -32,6 +30,24 @@ class PySCF_init_setup():
 
         return
 
+    def read_Tinker_inp_coord(self):
+
+        self.mol_data_init['Atoms_list'] = []
+        self.mol_data_init['Atoms_coord'] = []
+        with open(f"{self.init_data['topdir']}/{self.init_data['COM_file']}", 'r') as f:
+            next(f)
+            next(f)
+            for lines in f:
+                L = lines.strip('\n').split()
+                #print(L)
+                #if len(L)==4 and '#' not in L:
+                self.mol_data_init['Atoms_list'].append(L[0])
+                self.mol_data_init['Atoms_coord'].append([float(i) for i in L[1:]])
+
+
+        return
+
+
     def write_xyz(self,name):
 
         self.PySCF_inp_xyz = f"{self.init_data['COM_file'].strip('.com')}_{name}.xyz"
@@ -43,45 +59,55 @@ class PySCF_init_setup():
 
         return
 
-    def write_geometric_tor_const(self,name):
+    def write_geometric_tor_const(self,name,tor_const, tor_angle=None):
 
         self.PySCF_inp_const = f"PySCF_{name}_constraint.txt"
 
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_const}", 'w') as f:
             f.write('$set\n')
-            for tor in self.init_data['tor_rest']:
-                angle = self.mol_obj.GetTorsion(tor[0], tor[1], tor[2], tor[3]) % 360
+            for i,tor in enumerate(tor_const):
+                if tor_angle == None:
+                    angle = self.mol_obj.GetTorsion(tor[0], tor[1], tor[2], tor[3]) % 360
+                else:
+                    angme = tor_angle[i]
                 f.write(f'dihedral {tor[0]} {tor[1]} {tor[2]} {tor[3]} {angle:3.4f}\n')
 
         return
 
 
-    def write_PySCF_input(self):
+    def write_PySCF_input(self,is_opt=True,is_frag=False):
 
-        self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py" 
-        self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.log" 
+        if is_frag:
+            self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.xyz')}.py"
+            self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.xyz')}_pyscf.log" 
+        else:
+            self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py"
+            self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.log" 
 
-        self.write_PySCF_header()
+        self.write_PySCF_header(is_opt)
 
-        self.write_PySCF_params()
+        self.write_PySCF_params(is_opt)
 
-        self.write_PySCF_main()
+        self.write_PySCF_main(is_opt,is_frag)
 
-    def write_PySCF_header(self):
+    def write_PySCF_header(self,is_opt):
 
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'w') as f:
             f.write('import pyscf\n')
             f.write('from pyscf import gto, scf\n')
             f.write('from pyscf.dft import rks,uks\n')
             f.write('from pyscf import dft\n')
-            f.write('from pyscf.geomopt.geometric_solver import optimize\n\n')
+            if is_opt:
+                f.write('from pyscf.geomopt.geometric_solver import optimize\n\n')
 
         return
 
-    def write_PySCF_params(self):
+    def write_PySCF_params(self,is_opt):
 
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
-            f.write(f'params = {{"constraints": "{self.PySCF_inp_const}",\n')
+            f.write('params = {\n')
+            if is_opt:
+                f.write(f'"constraints": "{self.PySCF_inp_const}",\n')
             if self.pol_obj.optconvergence == 'LOOSE':
                 f.write('            "convergence_energy": 1e-4,\n') 
                 f.write('            "convergence_grms": 1.7e-3,\n') 
@@ -93,10 +119,24 @@ class PySCF_init_setup():
         return 
 
 
-    def write_PySCF_main(self):
+    def write_PySCF_main(self,is_opt,is_frag):
+
+        print('in PySCF main')
 
         atm_s = f'atom="{self.PySCF_inp_xyz}"'
-        basis_s = f'basis = "{self.pol_obj.optbasisset}"'
+        print(self.PySCF_inp_file)
+        if is_opt:
+            if not is_frag:
+                basis_s = f'basis = "{self.pol_obj.optbasisset}"'
+            else:
+                basis_s = f'basis = "{self.pol_obj.torspbasisset}"'
+        else:
+            if is_frag:
+                basis_s = f'basis = "{self.pol_obj.torspbasisset}"'
+            else:
+                raise Warning('PySCF is not set up to run PCM single point QM for parent ligand')
+                
+
         spin_s = f'spin = {int(self.mol_obj.GetTotalSpinMultiplicity())-1}'
         if self.mol_data_init['charge'] == None:
             chg_s = f'charge = {self.mol_obj.GetTotalCharge()}'
@@ -104,15 +144,27 @@ class PySCF_init_setup():
             chg_s = f'charge = {self.mol_data_init["charge"]}'
         unit_s = 'unit = "A"'
 
+        print(atm_s)
+        print(basis_s)
+        print(spin_s)
+        print(unit_s)
+
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
             f.write(f'mol = pyscf.M({atm_s}, {basis_s}, {spin_s}, {chg_s}, {unit_s})\n')
             f.write('mol.build()\n')
-            f.write(f'mf = pyscf.solvent.PCM(mol.UKS(xc = "{self.pol_obj.pyscf_opt_meth}").density_fit())\n')
+            if not is_frag:
+                f.write(f'mf = pyscf.solvent.PCM(mol.UKS(xc = "{self.pol_obj.pyscf_opt_meth}").density_fit())\n')
+            else:
+                f.write(f'mf = pyscf.solvent.PCM(mol.UKS(xc = "{self.pol_obj.pyscf_opt_meth}").density_fit())\n')
+                
             f.write(f'mf.with_solvent.method = "{self.pol_obj.pyscf_sol_imp}"\n')
             f.write(f'mf.with_solvent.eps = {self.pol_obj.pyscf_sol_eps}\n\n')
-            f.write(f'mol_eq = optimize(mf, maxsteps={self.pol_obj.optmaxcycle}, **params)\n')
-            f.write('print(f"Final optimized structure:")\n')
-            f.write('print(mol_eq.tostring())\n\n')
+            if is_opt:
+                f.write(f'mol_eq = optimize(mf, maxsteps={self.pol_obj.optmaxcycle}, **params)\n')
+                f.write('print(f"Final optimized structure:")\n')
+                f.write('print(mol_eq.tostring())\n\n')
+            else:
+                print('Need to add code for PySCF sp')
 
 
     
@@ -133,10 +185,7 @@ class PySCF_post_run():
         Geom = val.decode("utf-8").split()
         self.final_opt_xyz = f"{self.out_file.split('.log')[0]}.xyz"
 
-        cc = 0
         start = 3
-
-
         with open(f'{self.topdir}/{self.final_opt_xyz}', 'w') as file_1:
             file_1.write(f'{self.mol_obj.NumAtoms()}\n\n')
             for i in range(0,len(Geom[3:]),4):
@@ -144,6 +193,4 @@ class PySCF_post_run():
                 file_1.write(f'{" ".join([j for j in Geom[start:end]])}\n')
                 start = end
         
- 
-
-
+        return 

--- a/PoltypeModules/pyscf_setup.py
+++ b/PoltypeModules/pyscf_setup.py
@@ -78,15 +78,19 @@ class PySCF_init_setup():
     def write_PySCF_input(self,is_opt=True,is_frag=False):
 
         if is_frag:
-            self.PySCF_inp_file = f"{self.init_data['COM_file']}.py"
-            self.PySCF_out_file = f"{self.init_data['COM_file']}_pyscf.log" 
+            self.PySCF_inp_file = f"{self.init_data['COM_file']}_pyscf.py"
+            if is_opt:
+                self.PySCF_out_file = f"{self.init_data['COM_file']}_pyscf.log"
+            else:
+                self.PySCF_out_file = f"{self.init_data['COM_file']}.log"
         else:
-            self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}.py"
+            self.PySCF_inp_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.py"
             self.PySCF_out_file = f"{self.init_data['COM_file'].strip('.com')}_pyscf.log" 
 
         self.write_PySCF_header(is_opt)
 
-        self.write_PySCF_params(is_opt)
+        if is_opt:
+            self.write_PySCF_params()
 
         self.write_PySCF_main(is_opt,is_frag)
 
@@ -102,12 +106,11 @@ class PySCF_init_setup():
 
         return
 
-    def write_PySCF_params(self,is_opt):
+    def write_PySCF_params(self):
 
         with open(f"{self.init_data['topdir']}/{self.PySCF_inp_file}", 'a+') as f:
             f.write('params = {\n')
-            if is_opt:
-                f.write(f'"constraints": "{self.PySCF_inp_const}",\n')
+            f.write(f'"constraints": "{self.PySCF_inp_const}",\n')
             if self.pol_obj.optconvergence == 'LOOSE':
                 f.write('            "convergence_energy": 1e-4,\n') 
                 f.write('            "convergence_grms": 1.7e-3,\n') 
@@ -163,7 +166,11 @@ class PySCF_init_setup():
                 f.write(f'mol_eq = optimize(mf, maxsteps={self.pol_obj.optmaxcycle}, **params)\n')
                 f.write('print(f"Final optimized structure:")\n')
                 f.write('print(mol_eq.tostring())\n\n')
+                
             else:
+                f.write('mol_sp = mf.kernel()\n')
+                f.write('print(f"Final Energy: {mol_sp}")\n')
+                f.write('print("Normal Termination")\n')
                 print('Need to add code for PySCF sp')
 
 

--- a/PoltypeModules/torsionfit.py
+++ b/PoltypeModules/torsionfit.py
@@ -2237,6 +2237,5 @@ def ParsePYSCFEnergyLog(poltype,outputname):
     for line in open(outputname).readlines():
       if 'Final Energy: ' in line:
           L = line.rstrip('\n').split(':')[-1]
-          energy = float(L)
-
+          energy = float(L)*poltype.Hartree2kcal_mol
     return energy

--- a/PoltypeModules/torsionfit.py
+++ b/PoltypeModules/torsionfit.py
@@ -183,14 +183,10 @@ def compute_qm_tor_energy(poltype,torset,mol,flatphaselist):
         else:
             Soft = 'Psi4'
     
-    print('In Torsion fitting')
-    print('Soft', Soft)
-
     for phaseangles in flatphaselist:
         prefix='%s-%s-sp-' % (poltype.toroptmethod,poltype.torspmethod)
         postfix='.log' 
         minstrctfname,angles=torgen.GenerateFilename(poltype,torset,phaseangles,prefix,postfix,mol)
-        print(minstrctfname)
         if not os.path.exists(minstrctfname): # if optimization failed then SP file will not exist
             
             tor_energy=None
@@ -248,7 +244,6 @@ def compute_qm_tor_energy(poltype,torset,mol,flatphaselist):
         angle_list.append(angles)
         phaseangle_list.append(phaseangles)
 
-    print(energy_list)
     nonecount=energy_list.count(None)
     normalpts=len(energy_list)-nonecount
     if torset in poltype.torsionsettonumptsneeded.keys():
@@ -2238,7 +2233,6 @@ def ParsePYSCFEnergyLog(poltype,outputname):
     Referenced By: 
     Description: 
     """
-    print(outputname)
 
     for line in open(outputname).readlines():
       if 'Final Energy: ' in line:

--- a/PoltypeModules/torsiongenerator.py
+++ b/PoltypeModules/torsiongenerator.py
@@ -154,7 +154,6 @@ def ExecuteOptJobs(poltype,listofstructurestorunQM,phaselist,optmol,torset,varia
     executables=[]
     outputlogtoinitialxyz={}
     for i in range(len(listofstructurestorunQM)):
-        print('IN ExecuteOptJobs')
         torxyzfname=listofstructurestorunQM[i]
         phaseangles=phaselist[i]
         inputname,outputlog,cmdstr,scratchdir,executable=GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,variabletorlist,mol,currentopt)
@@ -206,11 +205,6 @@ def ExecuteSPJobs(poltype,optoutputlogs,phaselist,optmol,torset,variabletorlist,
     Description: 
     """
 
-    ######
-    # TM
-    ######
-
-
     jobtooutputlog={}
     listofjobs=[]
     outputnames=[]
@@ -218,14 +212,12 @@ def ExecuteSPJobs(poltype,optoutputlogs,phaselist,optmol,torset,variabletorlist,
     outputfilenames=[]
     executables=[]
 
+    # Check if PySCF is needed or not
     if poltype.use_gaus==False and poltype.use_gausoptonly==False:
         if poltype.toroptpcm==True or (poltype.toroptpcm==-1 and poltype.pcm):
             Soft = 'PySCF'
         else:
             Soft = 'Psi4'
-
-    print('TM: In ExecuteSPJobs')
-    print(Soft)
 
 
     for i in range(len(optoutputlogs)):
@@ -276,22 +268,11 @@ def ExecuteSPJobs(poltype,optoutputlogs,phaselist,optmol,torset,variabletorlist,
             postfix='.input'
             inputname,angles=GenerateFilename(poltype,torset,phaseangles,prefix,postfix,optmol)
             outputname=inputname.replace(postfix,'.log')
-
-            print(prevstrctfname)
-            print(executable)
-            print(prefix)
-            print(postfix)
-            print(inputname,angles)
-            print(outputname)
-
             pre=inputname.replace(postfix,'')
+
             from pyscf_for_frag import setup_frag_sp
 
             inputname,outputname,cmdstr= setup_frag_sp(poltype,optmol,prevstrctfname,pre)
-
-            print(inputname)
-            print(outputname)
-            print(cmdstr)
 
         finished,error=poltype.CheckNormalTermination(outputname,errormessages=None,skiperrors=True)
         inputfilepath=os.path.join(os.getcwd(),inputname)
@@ -396,17 +377,12 @@ def GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,va
     Referenced By: 
     Description: 
     """
-    print('In GenerateTorsionOptInputFile')
-    print('')
-    print('')
-    print('')
+
     if poltype.use_gaus==False and poltype.use_gausoptonly==False:
         if poltype.toroptpcm==True or (poltype.toroptpcm==-1 and poltype.pcm):
             Soft = 'PySCF'
         else:
             Soft = 'Psi4'
-
-    print(Soft)
 
     # Case: AMOEBA
     if poltype.toroptmethod=='AMOEBA':
@@ -450,9 +426,6 @@ def GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,va
         outputname=inputname.replace(postfix,'.log')
         optxyz,cmdstr=OptimizeXTB(poltype,inputstruct,resfilename,poltype.xtbmethod,outputname,mol.GetTotalCharge(),0)
         executable='xtb'
-
-        print(inputname,outputname,cmdstr,poltype.scrtmpdirpsi4,executable)
-
 
         return inputname,outputname,cmdstr,poltype.scrtmpdirpsi4,executable
     
@@ -519,11 +492,9 @@ def GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,va
         return inputname,outputname,cmdstr,poltype.scrtmpdirpsi4,executable
     
     
-    # In this case we are using either psi4 or Gaussian
+    # In this case we are using either psi4, PySCF or Gaussian
     else:
-        print('In here??????')
         if Soft == 'PySCF':
-            print('PYSCF!!!!!!!!')
             inputstruct=ConvertTinktoXYZ(poltype,torxyzfname,torxyzfname.replace('.xyz','_cart.xyz'))
             inputmol= opt.load_structfile(poltype,inputstruct)
             prefix=poltype.toroptmethod+'-opt-'
@@ -546,10 +517,7 @@ def GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,va
                 newtorset.append(tor)
 
             toranglelist=GrabTorsionAngles(poltype,newtorset,inputmol)
-            print(newtorset)
-            print(toranglelist)
-            print(pre)
-            print(inputstruct)
+
             from pyscf_for_frag import setup_frag_opt
             inputname,outputname,cmdstr = setup_frag_opt(poltype,newtorset,toranglelist,\
                                             pre,inputmol,inputname,inputstruct)
@@ -559,10 +527,7 @@ def GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,va
             return inputname,outputname,cmdstr,poltype.scrtmpdirpsi4,executable
             
 
-             #sys.exit()
         elif Soft == 'Psi4':
-            print('PSI4!!!!!')
-            sys.exit()
             inputname,outputname=CreatePsi4TorOPTInputFile(poltype,torset,phaseangles,optmol,torxyzfname,variabletorlist,mol,currentopt)
             cmdstr=' '.join(['psi4 ',poltype.psi4_args,inputname,outputname])
             executable='psi4'
@@ -1281,35 +1246,7 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
         else:
             poltype.toroptpcm=poltype.temptoroptpcm
             poltype.torsppcm=poltype.temptorsppcm
-        print('##########')
-        print('In gen_torsion')
-
-        print('listoftinkertorstructures',listoftinkertorstructures)
-        print('flatphaselist',flatphaselist)
-        print('torset',torset)
-        print('variabletorlist',variabletorlist)
-        print('torsionrestraint',torsionrestraint)
-        print('optlogtophaseangle',optlogtophaseangle)
-        print('')
-        print('')
-        print('')
         outputlogs,listofjobs,scratchdir,jobtooutputlog,initialstructures,optlogtophaseangle,inputfilepaths,outputfilenames,executables,outputlogtoinitialxyz=ExecuteOptJobs(poltype,listoftinkertorstructures,flatphaselist,optmol,torset,variabletorlist,torsionrestraint,mol,'1',optlogtophaseangle)
-
-        print('')
-        print('')
-        print('After ExecuteOptJobs')
-        print('outputlogs',outputlogs)
-        print('listofjobs',listofjobs)
-        print('scratchdir',scratchdir)
-        print('jobtooutputlog',jobtooutputlog)
-        print('initialstructures',initialstructures)
-        print('optlogtophaseangle',optlogtophaseangle)
-        print('inputfilepaths',inputfilepaths)
-        print('outputfilenames',outputfilenames)
-        print('executables',executables)
-        print('outputlogtoinitialxyz',outputlogtoinitialxyz)
-
-
 
         torsettooptoutputlogs[tuple(torset)]=outputlogs
         dictionary = dict(zip(outputlogs,initialstructures))  
@@ -1368,7 +1305,6 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
                     
 
         poltype.torsettophaselist[tuple(torset)]=newphaseangles
-    #sys.exit()
     firstfinishedjobs=finishedjobs[:]
     for job in firstfinishedjobs:
         if job not in finishedjobs:
@@ -1406,20 +1342,6 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
         torsettooptcputime[torset]=listofcputimesopt
         outputlogs,listofjobs,scratchdir,jobtooutputlog,outputlogtophaseangles,optlogtosplog,inputfilepaths,outputfilenames,executables=ExecuteSPJobs(poltype,finishedoutputlogs,finishedflatphaselist,optmol,torset,variabletorlist,torsionrestraint,outputlogtophaseangles,mol,optlogtosplog,optlogtophaseangle)
 
-        print('')
-        print('')
-        print('')
-        print('After ExecuteSPJobs')
-        print('outputlogs',outputlogs)
-        print('listofjobs',listofjobs)
-        print('scratchdir',scratchdir)
-        print('jobtooutputlog',jobtooutputlog)
-        print('outputlogtophaseangles',outputlogtophaseangles)
-        print('optlogtosplog',optlogtosplog)
-        print('inputfilepaths',inputfilepaths)
-        print('outputfilenames',outputfilenames)
-        print('executables',executables)
-        #sys.exit()
         lognames=[]
         torsettospoutputlogs[tuple(torset)]=outputlogs
         for jobidx in range(len(listofjobs)):
@@ -1438,18 +1360,12 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
         fulllistofjobs.extend(listofjobs)
         fulljobtolog.update(jobtolog)
 
-
-    
-
-
     jobtologlistfilenameprefix=os.getcwd()+r'/'+'QMSPJobToLog'+'_'+poltype.molecprefix
     if poltype.externalapi!=None:
         if len(fulllistofjobs)!=0:
-            print('In CallExternalAPI')
             call.CallExternalAPI(poltype,jobtoinputfilepaths,jobtooutputfiles,jobtoabsolutebinpath,scratchdir,jobtologlistfilenameprefix)
         ofinshedjobs,oerrorjobs=poltype.WaitForTermination(fulljobtooutputlog,False)
     else:
-        print('In CallJobsSeriallyLocalHost')
         ofinishedjobs,oerrorjobs=poltype.CallJobsSeriallyLocalHost(fulljobtooutputlog,True)
 
     for torset in poltype.torlist:

--- a/PoltypeModules/torsiongenerator.py
+++ b/PoltypeModules/torsiongenerator.py
@@ -510,12 +510,15 @@ def GenerateTorsionOptInputFile(poltype,torxyzfname,torset,phaseangles,optmol,va
             print(pre)
             print(inputstruct)
             from pyscf_for_frag import setup_frag_opt
-            PySCF_for_Frag = setup_frag_opt(poltype,newtorset,toranglelist,\
+            inputname,outputname,cmdstr = setup_frag_opt(poltype,newtorset,toranglelist,\
                                             pre,inputmol,inputname,inputstruct)
 
+            executable='python'
+
+            return inputname,outputname,cmdstr,poltype.scrtmpdirpsi4,executable
             
 
-            sys.exit()
+             #sys.exit()
         elif Soft == 'Psi4':
             print('PSI4!!!!!')
             sys.exit()
@@ -1246,9 +1249,27 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
         print('variabletorlist',variabletorlist)
         print('torsionrestraint',torsionrestraint)
         print('optlogtophaseangle',optlogtophaseangle)
-
+        print('')
+        print('')
+        print('')
         outputlogs,listofjobs,scratchdir,jobtooutputlog,initialstructures,optlogtophaseangle,inputfilepaths,outputfilenames,executables,outputlogtoinitialxyz=ExecuteOptJobs(poltype,listoftinkertorstructures,flatphaselist,optmol,torset,variabletorlist,torsionrestraint,mol,'1',optlogtophaseangle)
-        sys.exit()
+
+        print('')
+        print('')
+        print('After ExecuteOptJobs')
+        print('outputlogs',outputlogs)
+        print('listofjobs',listofjobs)
+        print('scratchdir',scratchdir)
+        print('jobtooutputlog',jobtooutputlog)
+        print('initialstructures',initialstructures)
+        print('optlogtophaseangle',optlogtophaseangle)
+        print('inputfilepaths',inputfilepaths)
+        print('outputfilenames',outputfilenames)
+        print('executables',executables)
+        print('outputlogtoinitialxyz',outputlogtoinitialxyz)
+
+
+
         torsettooptoutputlogs[tuple(torset)]=outputlogs
         dictionary = dict(zip(outputlogs,initialstructures))  
         torsettooutputlogtoinitialstructure[tuple(torset)].update(dictionary)
@@ -1291,7 +1312,11 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
             cartxyz=outputlog.replace('.log','.xyz')
             if finished==True:
                 if poltype.toroptmethod!='xtb' and poltype.toroptmethod!='ANI' and poltype.toroptmethod!='AMOEBA':
-                    opt.GrabFinalXYZStructure(poltype,outputlog,cartxyz,mol)
+                    if 'pyscf' in outputlog:
+                        from pyscf_for_frag import read_frag_opt
+                        read_frag_opt(poltype,outputlog,mol)
+                    else: 
+                        opt.GrabFinalXYZStructure(poltype,outputlog,cartxyz,mol)
                 CheckIfQMOptReachedTargetDihedral(poltype,cartxyz,initialtinkerstructure,torset,optmol,variabletorlist,phaseangles) # QM usually freezes dof but xtb and ANI does not freeze so need to add check now.
                 tinkerxyz=outputlog.replace('.log','_tinker.xyz')
                 ConvertCartesianXYZToTinkerXYZ(poltype,cartxyz,tinkerxyz)
@@ -1301,7 +1326,8 @@ def gen_torsion(poltype,optmol,torsionrestraint,mol):
                 newphaseangles.append(phsang)
                     
 
-        poltype.torsettophaselist[tuple(torset)]=newphaseangles         
+        poltype.torsettophaselist[tuple(torset)]=newphaseangles
+    sys.exit()
     firstfinishedjobs=finishedjobs[:]
     for job in firstfinishedjobs:
         if job not in finishedjobs:

--- a/PoltypeModules/torsiongenerator.py
+++ b/PoltypeModules/torsiongenerator.py
@@ -289,7 +289,7 @@ def ExecuteSPJobs(poltype,optoutputlogs,phaselist,optmol,torset,variabletorlist,
         outputlogtophaseangles[outputname]=phaseangles
         optlogtosplog[outputlog]=outputname
 
-    if not poltype.use_gaus or Soft == 'PySCF':
+    if not poltype.use_gaus and Soft == 'Psi4':
         
         return outputnames,listofjobs,poltype.scrtmpdirpsi4,jobtooutputlog,outputlogtophaseangles,optlogtosplog,inputfilepaths,outputfilenames,executables
     else:

--- a/PoltypeModules/vdwfit.py
+++ b/PoltypeModules/vdwfit.py
@@ -2402,6 +2402,7 @@ def VanDerWaalsOptimization(poltype,missingvdwatomindices):
             check=CheckIfFittingCompleted(poltype,prefix)
             checkarray.append(check)
             if poltype.use_qmopt_vdw==True:
+                print('HEREHEREHER')
                 poltype.comoptfname=prefix+'-opt.com'
                 poltype.chkoptfname=prefix+'-opt.chk'
                 poltype.fckoptfname=prefix+'-opt.fchk'


### PR DESCRIPTION
The goal of this PR is to add PySCF options to run PCM calculation in Poltype:

- [x] Create PySCF input file
- [x] Create geometric constraint file
- [x] Make sure proper success and failure are captured
- [x] Make sure the optimized geometry can be read afterward
- [x] Set up single point calculation for torsion PCM calculations
- [x] Test for both parent molecule and fragment